### PR TITLE
fix: correct Sucess to Success typo in success message (resetpass.go:70)

### DIFF
--- a/resetpass.go
+++ b/resetpass.go
@@ -67,7 +67,7 @@ func (p *resetPwCmd) Execute(_ context.Context, f *flag.FlagSet, _ ...interface{
 		fmt.Println("reset password: %v", err)
 		return subcommands.ExitFailure
 	}
-	fmt.Println("Sucess!")
+	fmt.Println("Success!")
 
 	//TODO:
 	fmt.Println()


### PR DESCRIPTION
## Summary
Corrects the typo `Sucess` → `Success` in a success message in `resetpass.go:70`.

## Change
```go
// Before
fmt.Println("Sucess!")
// After
fmt.Println("Success!")
```

## Testing
- Go syntax verified (1 file, 1 line change)